### PR TITLE
Using server name for EHLO instead of localhost

### DIFF
--- a/src/securesmtpclientbase.cpp
+++ b/src/securesmtpclientbase.cpp
@@ -260,7 +260,7 @@ int SecureSMTPClientBase::startTLSNegotiation() {
 int SecureSMTPClientBase::getServerSecureIdentification() {
     const int EHLO_SUCCESS_CODE = 250;
     addCommunicationLogItem("Contacting the server again but via the secure channel...");
-    std::string ehlo { "ehlo localhost\r\n"s };
+    std::string ehlo { "ehlo " + getServerName() + "\r\n" };
     addCommunicationLogItem(ehlo.c_str());
     int tls_command_return_code = sendCommandWithFeedback(ehlo.c_str(),
             SSL_CLIENT_INITSECURECLIENT_ERROR,

--- a/src/smtpclientbase.cpp
+++ b/src/smtpclientbase.cpp
@@ -657,7 +657,7 @@ int SMTPClientBase::setSocketToBlocking() {
 
 int SMTPClientBase::sendServerIdentification() {
     const int EHLO_SUCCESS_CODE = 250;
-    std::string ehlo { "ehlo localhost\r\n" };
+    std::string ehlo { "ehlo " + getServerName() + "\r\n" };
     addCommunicationLogItem(ehlo.c_str());
     int command_return_code = sendCommandWithFeedback(ehlo.c_str(),
             SOCKET_INIT_CLIENT_SEND_EHLO_ERROR,


### PR DESCRIPTION
There are certain services that do not allow EHLO localhost (Fastmail is one example). RFC 5321 requires the HELO/EHLO command to provide a valid FQDN or an IP address literal.

