### PR TITLE
Adding mHostName + accessor/mutator and using with EHLO rather than localhost

### DIFF
--- a/src/cpp/opportunisticsecuresmtpclient.cpp
+++ b/src/cpp/opportunisticsecuresmtpclient.cpp
@@ -99,3 +99,11 @@ jed_utils::ServerAuthOptions *OpportunisticSecureSMTPClient::extractAuthenticati
 int OpportunisticSecureSMTPClient::sendMail(const jed_utils::Message &pMsg) {
     return jed_utils::OpportunisticSecureSMTPClient::sendMail(pMsg);
 }
+
+std::string OpportunisticSecureSMTPClient::getHostName() const {
+    return jed_utils::OpportunisticSecureSMTPClient::getHostName();
+}
+
+void OpportunisticSecureSMTPClient::setHostName(const std::string &pHostName) {
+    jed_utils::OpportunisticSecureSMTPClient::setHostName(pHostName.c_str());
+}

--- a/src/cpp/opportunisticsecuresmtpclient.hpp
+++ b/src/cpp/opportunisticsecuresmtpclient.hpp
@@ -150,6 +150,16 @@ class CPP_OPPORTUNISTICSECURESMTPCLIENT_API OpportunisticSecureSMTPClient : priv
 
     int sendMail(const jed_utils::Message &pMsg);
 
+    /** Return the hostname name. */
+    std::string getHostName() const;
+
+    /**
+     *  @brief  Set the host name.
+     *  @param pHostName A char array pointer of the host name.
+     *  Example: smtp.domainexample.com
+     */
+    void setHostName(const std::string &pHostName);
+
  protected:
     static int extractReturnCode(const std::string &pOutput);
     static jed_utils::ServerAuthOptions *extractAuthenticationOptions(const std::string &pEhloOutput);

--- a/src/securesmtpclientbase.cpp
+++ b/src/securesmtpclientbase.cpp
@@ -260,7 +260,8 @@ int SecureSMTPClientBase::startTLSNegotiation() {
 int SecureSMTPClientBase::getServerSecureIdentification() {
     const int EHLO_SUCCESS_CODE = 250;
     addCommunicationLogItem("Contacting the server again but via the secure channel...");
-    std::string ehlo { "ehlo localhost\r\n"s };
+    std::string hostname{ getHostName() };
+    std::string ehlo { "ehlo " + hostname + "\r\n"s };
     addCommunicationLogItem(ehlo.c_str());
     int tls_command_return_code = sendCommandWithFeedback(ehlo.c_str(),
             SSL_CLIENT_INITSECURECLIENT_ERROR,

--- a/src/smtpclientbase.cpp
+++ b/src/smtpclientbase.cpp
@@ -53,6 +53,7 @@ using namespace jed_utils;
 SMTPClientBase::SMTPClientBase(const char *pServerName, unsigned int pPort)
     : mIsConnected(false),
       mServerName(nullptr),
+      mHostName(nullptr),
       mPort(pPort),
       mBatchMode(false),
       mCommunicationLog(nullptr),
@@ -73,12 +74,26 @@ SMTPClientBase::SMTPClientBase(const char *pServerName, unsigned int pPort)
     mServerName = new char[server_name_len + 1];
     strncpy(mServerName, pServerName, server_name_len);
     mServerName[server_name_len] = '\0';
+    const char* pHostName = "localhost";
+    std::string hostname_str{ pHostName == nullptr ? "" : pHostName };
+    if (pHostName == nullptr || strcmp(pHostName, "") == 0 || StringUtils::trim(hostname_str).empty()) {
+        throw std::invalid_argument("Host name cannot be null or empty");
+    }
+    size_t host_name_len = strlen(pHostName);
+    mHostName = new char[host_name_len + 1];
+    strncpy(mHostName, pHostName, host_name_len);
+    mHostName[host_name_len] = '\0';
     generate_separator(mSeparator);
+
+
+    setHostName("localhost");
 }
 
 SMTPClientBase::~SMTPClientBase() {
     delete[] mServerName;
     mServerName = nullptr;
+    delete[] mHostName;
+    mHostName = nullptr;
     delete[] mCommunicationLog;
     mCommunicationLog = nullptr;
     delete[] mLastServerResponse;
@@ -93,6 +108,7 @@ SMTPClientBase::~SMTPClientBase() {
 SMTPClientBase::SMTPClientBase(const SMTPClientBase& other)
     : mIsConnected(false),
       mServerName(new char[strlen(other.mServerName) + 1]),
+      mHostName(new char[strlen(other.mHostName) + 1]),
       mPort(other.mPort),
       mBatchMode(other.mBatchMode),
       mCommunicationLog(other.mCommunicationLog != nullptr ? new char[strlen(other.mCommunicationLog) + 1]: nullptr),
@@ -110,6 +126,9 @@ SMTPClientBase::SMTPClientBase(const SMTPClientBase& other)
     size_t server_name_len = strlen(other.mServerName);
     strncpy(mServerName, other.mServerName, server_name_len);
     mServerName[server_name_len] = '\0';
+    size_t host_name_len = strlen(other.mHostName);
+    strncpy(mHostName, other.mHostName, host_name_len);
+    mHostName[host_name_len] = '\0';
     if (mCommunicationLog != nullptr) {
         size_t communication_log_len = strlen(other.mCommunicationLog);
         strncpy(mCommunicationLog, other.mCommunicationLog, communication_log_len);
@@ -135,6 +154,11 @@ SMTPClientBase& SMTPClientBase::operator=(const SMTPClientBase& other) {
         mServerName = new char[server_name_len + 1];
         strncpy(mServerName, other.mServerName, server_name_len);
         mServerName[server_name_len] = '\0';
+        delete[] mHostName;
+        size_t host_name_len = strlen(other.mHostName);
+        mHostName = new char[host_name_len + 1];
+        strncpy(mHostName, other.mHostName, server_name_len);
+        mHostName[host_name_len] = '\0';
         // mPort
         mPort = other.mPort;
         // mBatchMode
@@ -176,6 +200,7 @@ SMTPClientBase& SMTPClientBase::operator=(const SMTPClientBase& other) {
 SMTPClientBase::SMTPClientBase(SMTPClientBase&& other) noexcept
     : mIsConnected(other.mIsConnected),
       mServerName(other.mServerName),
+      mHostName(other.mHostName),
       mPort(other.mPort),
       mBatchMode(other.mBatchMode),
       mCommunicationLog(other.mCommunicationLog),
@@ -190,6 +215,7 @@ SMTPClientBase::SMTPClientBase(SMTPClientBase&& other) noexcept
       mKeepUsingBaseSendCommands(other.mKeepUsingBaseSendCommands),
       sendCommandPtr(&SMTPClientBase::sendCommand),
       sendCommandWithFeedbackPtr(&SMTPClientBase::sendCommandWithFeedback) {
+    other.mServerName = nullptr;
     other.mServerName = nullptr;
     other.mPort = 0;
     other.mBatchMode = false;
@@ -214,12 +240,14 @@ SMTPClientBase::SMTPClientBase(SMTPClientBase&& other) noexcept
 SMTPClientBase& SMTPClientBase::operator=(SMTPClientBase&& other) noexcept {
     if (this != &other) {
         delete[] mServerName;
+        delete[] mHostName;
         delete[] mCommunicationLog;
         delete[] mLastServerResponse;
         delete mAuthOptions;
         delete mCredential;
         // Copy the data pointer and its length from the source object.
         mServerName = other.mServerName;
+        mHostName = other.mHostName;
         mPort = other.mPort;
         mBatchMode = other.mBatchMode;
         mCommunicationLog = other.mCommunicationLog;
@@ -239,6 +267,7 @@ SMTPClientBase& SMTPClientBase::operator=(SMTPClientBase&& other) noexcept {
         // Release the data pointer from the source object so that
         // the destructor does not free the memory multiple times.
         other.mServerName = nullptr;
+        other.mHostName = nullptr;
         other.mPort = 0;
         other.mBatchMode = false;
         other.mCommunicationLog = nullptr;
@@ -409,6 +438,22 @@ int SMTPClientBase::sendMail(const Message &pMsg) {
     return 0;
 }
 
+
+const char* SMTPClientBase::getHostName() const {
+    return mHostName;
+}
+
+void SMTPClientBase::setHostName(const char* pHostName) {
+    std::string hostname_str{ pHostName == nullptr ? "" : pHostName };
+    if (pHostName == nullptr || strcmp(pHostName, "") == 0 || StringUtils::trim(hostname_str).empty()) {
+        throw std::invalid_argument("Host name cannot be null or empty");
+    }
+    delete[]mHostName;
+    size_t host_name_len = strlen(pHostName);
+    mHostName = new char[host_name_len + 1];
+    strncpy(mHostName, pHostName, host_name_len);
+    mHostName[host_name_len] = '\0';
+}
 
 int SMTPClientBase::initializeSession() {
     delete[] mCommunicationLog;
@@ -657,7 +702,8 @@ int SMTPClientBase::setSocketToBlocking() {
 
 int SMTPClientBase::sendServerIdentification() {
     const int EHLO_SUCCESS_CODE = 250;
-    std::string ehlo { "ehlo localhost\r\n" };
+    std::string hostname{ getHostName() };
+    std::string ehlo{ "ehlo " + hostname + "\r\n" };
     addCommunicationLogItem(ehlo.c_str());
     int command_return_code = sendCommandWithFeedback(ehlo.c_str(),
             SOCKET_INIT_CLIENT_SEND_EHLO_ERROR,

--- a/src/smtpclientbase.h
+++ b/src/smtpclientbase.h
@@ -168,6 +168,16 @@ class SMTPCLIENTBASE_API SMTPClientBase {
 
     int sendMail(const Message &pMsg);
 
+    /** Return the hostname name. */
+    const char* getHostName() const;
+
+    /**
+     *  @brief  Set the host name.
+     *  @param pHostName A char array pointer of the host name.
+     *  Example: smtp.domainexample.com
+     */
+    void setHostName(const char* pHostName);
+
  protected:
     bool mIsConnected;
     virtual void cleanup() = 0;
@@ -229,6 +239,7 @@ class SMTPCLIENTBASE_API SMTPClientBase {
 
  private:
     char *mServerName;
+    char *mHostName;
     unsigned int mPort;
     bool mBatchMode;
     char *mCommunicationLog;


### PR DESCRIPTION
There are certain services that do not allow EHLO localhost (Fastmail is one example). RFC 5321 requires the HELO/EHLO command to provide a valid FQDN or an IP address literal.

* Updated C++ interface + C Interface to add getHostName and setHostName
* Tested with FastMail, validated on Linux (Debian 13)
* Compilation validated on Windows & Linux
* mHostName is "localhost" by default, so no behaviour changes by default.