### PR TITLE
Fix parsing of auth options

### DIFF
--- a/src/smtpclientbase.cpp
+++ b/src/smtpclientbase.cpp
@@ -1210,9 +1210,9 @@ ServerAuthOptions *SMTPClientBase::extractAuthenticationOptions(const char *pEhl
             break;
         }
         ehlo_output.erase(0, ehlo_character_index + DELIMITER.length());
-        if (!ehlo_output.empty() && retVal == nullptr) {
-            retVal = ParseAuthenticationOptions(ehlo_output);
-        }
+    }
+    if (!ehlo_output.empty() && retVal == nullptr) {
+        retVal = ParseAuthenticationOptions(ehlo_output);
     }
     return retVal;
 }


### PR DESCRIPTION
See issue #59 

Current implementation has a memory leak and is double parsing each line.  I think the code submitted in this PR is what was originally intended.